### PR TITLE
Add spaceFN to linux

### DIFF
--- a/arch/kmonad/leopold_fc660c.kbd
+++ b/arch/kmonad/leopold_fc660c.kbd
@@ -1,0 +1,35 @@
+(defcfg
+    input (device-file "/dev/input/by-id/usb-LEOPOLD_Mini_Keyboard-event-kbd")
+    output (uinput-sink "kmonad output")
+    fallthrough true
+)
+
+(defsrc
+    grv  1    2    3    4    5    6    7    8    9    0    -    =    bspc
+    tab  q    w    e    r    t    y    u    i    o    p    [    ]    \
+    caps a    s    d    f    g    h    j    k    l    ;    '    ret
+    lsft z    x    c    v    b    n    m    ,    .    /    rsft
+    lctl met  lalt           spc            ralt rctl lft  up   down rght
+)
+
+;; Default layout aliases
+(defalias
+    spc (tap-next-release spc (layer-toggle spacefn))
+    ce  (tap-next esc lctl)
+)
+
+(deflayer default
+    grv  1    2    3    4    5    6    7    8    9    0    -    =    bspc
+    tab  q    w    e    r    t    y    u    i    o    p    [    ]    \
+    @ce  a    s    d    f    g    h    j    k    l    ;    '    ret
+    lsft z    x    c    v    b    n    m    ,    .    /    rsft
+    lctl lalt lmet           @spc           ralt rctl lft  up   down rght
+)
+
+(deflayer spacefn
+    _    f1   f2   f3   f4   f5   f6   f7   f8   f9   f10  f11  f12  _
+    _    _    _    _    _    _    del  home ins  end  prev _    _    _
+    _    _    _    _    _    _    lft  down up   rght _    _    _
+    _    _    _    _    _    spc  next pp   vold volu _    _
+    _    _    _              _              _    _    _    _    _    _
+)


### PR DESCRIPTION
I have read and used this feature way too much in my life. Here's what's needed to know about this:

- [the original idea in geekhack](https://geekhack.org/index.php?topic=51069.0)
- how i came to know about this idea: [wincent's video](https://www.youtube.com/watch?v=DINWg9X8MNg)
- [my notes on implementing spacefn in a Drop ALT keyboard](https://www.anachronic.io/wiki/alt-keyboard). Unfortunately, that keyboard is no longer with me 😞
- [My current implementation in macOS](https://github.com/anachronic/dotfiles/blob/da4578730de75e9afd479b0ac64a937a7ccd20ab/macos/link/.config/karabiner/karabiner.json). I use it extensively but karabiner hasn't been the best lately.
- [a succesful use of spacefn in linux](https://github.com/anachronic/spacefn-evdev) that requires the use of sudo and some other hacks. It also keeps the screen awake for some reason. Not great but does the job.
- [interception-vimproved](https://github.com/maricn/interception-vimproved). Was a great idea but doesn't take rollover into account and doesn't fit my typing style it seems.

👆 You can see that I've tried **many** times to have this feature in Linux and it hasn't been easy at all. After that I found [kmonad](https://github.com/kmonad/kmonad) and [kbct](https://github.com/samvel1024/kbct). kmonad seems way easier and mature and so I decided to go with that one. That will do 👍